### PR TITLE
Allow custom target uploads

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pixel Morph</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="app-container">
+      <header>
+        <h1>Pixel Morph</h1>
+        <p class="tagline">Transform your image into a new iconic silhouette.</p>
+      </header>
+
+      <section id="controls" aria-label="Controls">
+        <div class="control-group">
+          <label for="targetImageUpload" class="control-label">Select Target Image</label>
+          <input type="file" id="targetImageUpload" accept="image/*" />
+        </div>
+        <div class="control-group">
+          <label for="sourceImageUpload" class="control-label">Select Source Image</label>
+          <input type="file" id="sourceImageUpload" accept="image/*" />
+        </div>
+        <div class="buttons">
+          <button id="transformButton" disabled>Transform!</button>
+          <button id="resetButton" class="secondary">Reset</button>
+          <button id="drawingModeButton" class="secondary" aria-pressed="false" disabled>
+            Drawing Mode
+          </button>
+        </div>
+      </section>
+
+      <canvas id="displayCanvas" width="512" height="512" role="img" aria-label="Pixel morph display"></canvas>
+
+      <p class="hint">
+        Upload a 512×512 target image to morph toward, then choose a source image or switch to
+        Drawing Mode to paint pixels that will flow into the target silhouette.
+      </p>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,357 @@
+const CANVAS_SIZE = 512;
+const EASING = 0.08;
+const STOP_THRESHOLD = 0.35;
+
+const canvas = document.getElementById("displayCanvas");
+const ctx = canvas.getContext("2d");
+const targetInput = document.getElementById("targetImageUpload");
+const fileInput = document.getElementById("sourceImageUpload");
+const transformButton = document.getElementById("transformButton");
+const resetButton = document.getElementById("resetButton");
+const drawingModeButton = document.getElementById("drawingModeButton");
+
+let sourcePixels = [];
+let targetPixels = [];
+let targetPixelsSorted = [];
+let particles = [];
+let animationFrameId = null;
+let isAnimating = false;
+let drawingMode = false;
+let targetAssignmentIndex = 0;
+let isMouseDown = false;
+
+/**
+ * Calculate perceived brightness for a pixel.
+ * @param {number} r
+ * @param {number} g
+ * @param {number} b
+ * @returns {number}
+ */
+function getBrightness(r, g, b) {
+  return r * 0.299 + g * 0.587 + b * 0.114;
+}
+
+/**
+ * Convert an HTMLImageElement into an array of pixel objects.
+ * Transparent pixels are omitted to limit particle count.
+ * @param {HTMLImageElement} image
+ * @param {number} [width=CANVAS_SIZE]
+ * @param {number} [height=CANVAS_SIZE]
+ * @returns {Array<{x:number, y:number, color:string, brightness:number}>>}
+ */
+function getPixelDataFromImage(image, width = CANVAS_SIZE, height = CANVAS_SIZE) {
+  const offscreenCanvas = document.createElement("canvas");
+  offscreenCanvas.width = width;
+  offscreenCanvas.height = height;
+  const offscreenCtx = offscreenCanvas.getContext("2d", { willReadFrequently: true });
+
+  offscreenCtx.clearRect(0, 0, width, height);
+  offscreenCtx.drawImage(image, 0, 0, width, height);
+
+  const { data } = offscreenCtx.getImageData(0, 0, width, height);
+  const pixels = [];
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const index = (y * width + x) * 4;
+      const r = data[index];
+      const g = data[index + 1];
+      const b = data[index + 2];
+      const a = data[index + 3];
+
+      if (a === 0) continue;
+
+      const alpha = a / 255;
+      pixels.push({
+        x,
+        y,
+        color: `rgba(${r}, ${g}, ${b}, ${alpha.toFixed(3)})`,
+        brightness: getBrightness(r, g, b),
+      });
+    }
+  }
+
+  return pixels;
+}
+
+/**
+ * Prepare the particles array by mapping sorted source pixels to target pixels.
+ */
+function createParticleMapping() {
+  if (!sourcePixels.length || !targetPixelsSorted.length) return;
+
+  const sortedSource = [...sourcePixels].sort((a, b) => a.brightness - b.brightness);
+  const count = Math.min(sortedSource.length, targetPixelsSorted.length);
+
+  particles = new Array(count);
+
+  for (let i = 0; i < count; i += 1) {
+    const src = sortedSource[i];
+    const tgt = targetPixelsSorted[i];
+    particles[i] = {
+      currentX: src.x,
+      currentY: src.y,
+      targetX: tgt.x,
+      targetY: tgt.y,
+      color: src.color,
+    };
+  }
+}
+
+/**
+ * Draw the source image onto the canvas for immediate visual feedback.
+ * @param {HTMLImageElement} image
+ */
+function displaySourceImage(image) {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+}
+
+/**
+ * Animation loop.
+ */
+function animate() {
+  if (!particles.length) {
+    isAnimating = false;
+    return;
+  }
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  let particlesAtRest = 0;
+
+  for (let i = 0; i < particles.length; i += 1) {
+    const particle = particles[i];
+    const dx = particle.targetX - particle.currentX;
+    const dy = particle.targetY - particle.currentY;
+
+    particle.currentX += dx * EASING;
+    particle.currentY += dy * EASING;
+
+    if (Math.abs(dx) < STOP_THRESHOLD && Math.abs(dy) < STOP_THRESHOLD) {
+      particlesAtRest += 1;
+    }
+
+    ctx.fillStyle = particle.color;
+    ctx.fillRect(particle.currentX, particle.currentY, 1, 1);
+  }
+
+  if (particlesAtRest === particles.length) {
+    isAnimating = false;
+    animationFrameId = null;
+    return;
+  }
+
+  animationFrameId = requestAnimationFrame(animate);
+}
+
+/**
+ * Start the animation loop if it isn't already running.
+ */
+function ensureAnimation() {
+  if (!isAnimating) {
+    isAnimating = true;
+    animationFrameId = requestAnimationFrame(animate);
+  }
+}
+
+/**
+ * Stop the current animation frame loop.
+ */
+function stopAnimation() {
+  if (animationFrameId) {
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+  isAnimating = false;
+}
+
+/**
+ * Reset the application state.
+ */
+function reset() {
+  stopAnimation();
+  particles = [];
+  sourcePixels = [];
+  targetAssignmentIndex = 0;
+  fileInput.value = "";
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  if (drawingMode) {
+    drawingMode = false;
+    drawingModeButton.setAttribute("aria-pressed", "false");
+    drawingModeButton.textContent = "Drawing Mode";
+  }
+
+  updateControlStates();
+}
+
+/**
+ * Toggle drawing mode and update button state.
+ */
+function toggleDrawingMode() {
+  if (!targetPixelsSorted.length) {
+    return;
+  }
+
+  drawingMode = !drawingMode;
+  drawingModeButton.setAttribute("aria-pressed", String(drawingMode));
+  drawingModeButton.textContent = drawingMode ? "Drawing Mode: On" : "Drawing Mode";
+
+  if (drawingMode) {
+    stopAnimation();
+    particles = [];
+    targetAssignmentIndex = 0;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  updateControlStates();
+}
+
+/**
+ * Handle drawing on the canvas to create particles manually.
+ * @param {number} clientX
+ * @param {number} clientY
+ */
+function handleDraw(clientX, clientY) {
+  if (!drawingMode || !targetPixelsSorted.length) return;
+  const rect = canvas.getBoundingClientRect();
+  const scaleX = canvas.width / rect.width;
+  const scaleY = canvas.height / rect.height;
+  const x = Math.floor((clientX - rect.left) * scaleX);
+  const y = Math.floor((clientY - rect.top) * scaleY);
+
+  const brushSize = 4;
+  for (let offsetX = -brushSize; offsetX <= brushSize; offsetX += 1) {
+    for (let offsetY = -brushSize; offsetY <= brushSize; offsetY += 1) {
+      const distance = Math.hypot(offsetX, offsetY);
+      if (distance > brushSize) continue;
+
+      const px = x + offsetX;
+      const py = y + offsetY;
+
+      if (px < 0 || py < 0 || px >= canvas.width || py >= canvas.height) continue;
+      if (targetAssignmentIndex >= targetPixelsSorted.length) return;
+
+      const target = targetPixelsSorted[targetAssignmentIndex];
+      targetAssignmentIndex += 1;
+
+      particles.push({
+        currentX: px,
+        currentY: py,
+        targetX: target.x,
+        targetY: target.y,
+        color: "rgba(255, 255, 255, 1)",
+      });
+    }
+  }
+
+  updateControlStates();
+  ensureAnimation();
+}
+
+// Event bindings
+transformButton.addEventListener("click", () => {
+  if (drawingMode) {
+    ensureAnimation();
+    return;
+  }
+
+  if (!sourcePixels.length || !targetPixelsSorted.length) return;
+
+  stopAnimation();
+  createParticleMapping();
+  ensureAnimation();
+});
+
+resetButton.addEventListener("click", () => {
+  reset();
+});
+
+drawingModeButton.addEventListener("click", toggleDrawingMode);
+
+canvas.addEventListener("mousedown", (event) => {
+  if (!drawingMode) return;
+  isMouseDown = true;
+  handleDraw(event.clientX, event.clientY);
+});
+
+canvas.addEventListener("mousemove", (event) => {
+  if (!drawingMode || !isMouseDown) return;
+  handleDraw(event.clientX, event.clientY);
+});
+
+window.addEventListener("mouseup", () => {
+  isMouseDown = false;
+});
+
+fileInput.addEventListener("change", (event) => {
+  const file = event.target.files?.[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = ({ target }) => {
+    if (!target?.result) return;
+
+    const image = new Image();
+    image.onload = () => {
+      stopAnimation();
+      sourcePixels = getPixelDataFromImage(image, CANVAS_SIZE, CANVAS_SIZE);
+      displaySourceImage(image);
+      drawingMode = false;
+      drawingModeButton.setAttribute("aria-pressed", "false");
+      drawingModeButton.textContent = "Drawing Mode";
+      particles = [];
+      targetAssignmentIndex = 0;
+      updateControlStates();
+    };
+    image.src = target.result;
+  };
+
+  reader.readAsDataURL(file);
+});
+
+targetInput.addEventListener("change", (event) => {
+  const file = event.target.files?.[0];
+  if (!file) {
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = ({ target }) => {
+    if (!target?.result) return;
+
+    const image = new Image();
+    image.onload = () => {
+      targetPixels = getPixelDataFromImage(image, CANVAS_SIZE, CANVAS_SIZE);
+      targetPixelsSorted = [...targetPixels].sort((a, b) => a.brightness - b.brightness);
+      targetAssignmentIndex = 0;
+      particles = [];
+      stopAnimation();
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      updateControlStates();
+    };
+    image.src = target.result;
+  };
+
+  reader.readAsDataURL(file);
+});
+
+function updateControlStates() {
+  const hasTarget = targetPixelsSorted.length > 0;
+  const hasSource = sourcePixels.length > 0;
+  const hasDrawingParticles = particles.length > 0;
+  const canTransformFromSource = hasTarget && hasSource && !drawingMode;
+  const canTransformFromDrawing = hasTarget && drawingMode && hasDrawingParticles;
+
+  transformButton.disabled = !(canTransformFromSource || canTransformFromDrawing);
+  drawingModeButton.disabled = !hasTarget;
+}
+
+function initialize() {
+  canvas.width = CANVAS_SIZE;
+  canvas.height = CANVAS_SIZE;
+  updateControlStates();
+}
+
+document.addEventListener("DOMContentLoaded", initialize);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,160 @@
+:root {
+  color-scheme: light dark;
+  --background: #10151d;
+  --surface: rgba(255, 255, 255, 0.06);
+  --surface-light: rgba(255, 255, 255, 0.12);
+  --primary: #4c8bf5;
+  --accent: #f5a623;
+  --text: #f1f5f9;
+  --text-muted: #a9b4c2;
+  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 20% 20%, rgba(76, 139, 245, 0.25), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(245, 166, 35, 0.25), transparent 60%),
+    var(--background);
+  color: var(--text);
+  padding: 2rem;
+}
+
+.app-container {
+  width: min(90vw, 720px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 2.5rem;
+  backdrop-filter: blur(18px);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.25);
+}
+
+header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: 0.04em;
+}
+
+.tagline {
+  margin: 0.25rem 0 0;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+#controls {
+  display: grid;
+  gap: 1rem;
+  background: var(--surface);
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.control-label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+input[type="file"] {
+  padding: 0.75rem 1rem;
+  border: 1px dashed rgba(255, 255, 255, 0.25);
+  border-radius: 8px;
+  background: rgba(10, 15, 24, 0.6);
+  color: var(--text-muted);
+}
+
+.buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+#transformButton {
+  background: linear-gradient(135deg, var(--primary), #89b6ff);
+  color: #0b0f1a;
+  box-shadow: 0 10px 24px rgba(76, 139, 245, 0.4);
+}
+
+button.secondary {
+  background: var(--surface-light);
+  color: var(--text);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.3);
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.35);
+}
+
+button[aria-pressed="true"] {
+  background: linear-gradient(135deg, var(--accent), #ffd79a);
+  color: #0f121b;
+}
+
+#displayCanvas {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  border-radius: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  background: rgba(5, 8, 12, 0.85);
+}
+
+.hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  .app-container {
+    padding: 1.75rem;
+  }
+
+  #controls {
+    padding: 1.25rem;
+  }
+
+  button {
+    width: 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add a target image upload control and updated guidance in the interface
- update the morphing engine to derive target pixels from user uploads and adjust control enablement accordingly
- remove the bundled Obama reference asset so users can provide any target artwork

## Testing
- not run (static frontend project)

------
https://chatgpt.com/codex/tasks/task_e_68d9f85f1a808333b99fde8d71f27bb5